### PR TITLE
Add support for unmarshaling secrets in a json payload

### DIFF
--- a/secret.go
+++ b/secret.go
@@ -1,6 +1,7 @@
 package secrecy
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -61,6 +62,10 @@ func (s Secret[T]) GoString() string {
 // easily searched.
 func (s Secret[T]) MarshalText() ([]byte, error) {
 	return []byte(SecretLeakedMarker), nil
+}
+
+func (s *Secret[T]) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &s.value)
 }
 
 // Disable zeroize on garbage collection for this secret.

--- a/secret_test.go
+++ b/secret_test.go
@@ -89,6 +89,20 @@ func TestSecret(t *testing.T) {
 		}
 	})
 
+	t.Run("json.Unmarshal", func(t *testing.T) {
+		bytes := []byte(`"mysecret"`)
+		var secret Secret[string]
+		err := json.Unmarshal(bytes, &secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		str := secret.value
+
+		if str != "mysecret" {
+			t.Fatal("json.Unmarshal invalid value:", str)
+		}
+	})
+
 	t.Run("xml.Marshal", func(t *testing.T) {
 		secret := NewSecret("mysecret")
 		bytes, err := xml.Marshal(secret)

--- a/serializable_secret.go
+++ b/serializable_secret.go
@@ -30,3 +30,7 @@ func (ss SerializableSecret[S, T]) MarshalJSON() ([]byte, error) {
 	secret := ss.ExposeSecret()
 	return json.Marshal(secret)
 }
+
+func (ss *SerializableSecret[S, T]) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &ss.secret)
+}

--- a/serializable_secret_test.go
+++ b/serializable_secret_test.go
@@ -19,4 +19,18 @@ func TestSerializableSecret(t *testing.T) {
 			t.Fatal("json.Marshal(SerializableSecret) didn't serialize the secret:", str)
 		}
 	})
+
+	t.Run("json.Unmarshal", func(t *testing.T) {
+		bytes := []byte(`"mysecret"`)
+		var secret SerializableSecret[string, *Secret[string]]
+		err := json.Unmarshal(bytes, &secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		str := secret.ExposeSecret()
+
+		if str != "mysecret" {
+			t.Fatal("json.Unmarshal invalid value:", str)
+		}
+	})
 }


### PR DESCRIPTION
This change makes it possible to deserialize a json payload to a struct that has secret values, without having to manually create the secrets.

Example:
```go
type Auth struct {
	Username string
	Password secrecy.Secret[string]
}

type User struct {
	FirstName string
	LastName  string
	Email     secrecy.Secret[string]  // We don't want this PII in our logs
	Auth      Auth
}

func main() {
	payload := `
	{
		"firstName": "John",
		"lastName": "Doe",
		"email": "john.doe@example.com",
		"auth": {
			"username": "admin",
			"password": "admin"
		}
	}
	`

	var user User
	err := json.Unmarshal([]byte(payload), &user)
	if err != nil {
		log.Fatalf("unmarshaling error: %v", err)
	}

	log.Printf("User: %+v", user)  // The email and passwords will be redacted
}
```